### PR TITLE
Adding pull to refresh and header view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/com/example/capway/MainActivity.kt
+++ b/app/src/main/java/com/example/capway/MainActivity.kt
@@ -3,8 +3,6 @@ package com.example.capway
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.FragmentManager
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import kotlinx.android.synthetic.main.main_activity.*
 
 class MainActivity : FragmentActivity(), View.OnClickListener {

--- a/app/src/main/res/layout/transactions_fragment.xml
+++ b/app/src/main/res/layout/transactions_fragment.xml
@@ -3,7 +3,44 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/header"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        app:layout_constraintTop_toTopOf="parent"
+        android:paddingBottom="10dp"
+        android:background="@color/white"
+        android:alpha="1"
+        android:elevation="1dp"
+        android:visibility="gone">
+        <TextView
+            android:id="@+id/header_account_balance"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="14dp"
+            android:layout_marginLeft="14dp"
+            style="@style/accountBalance"/>
+        <TextView
+            android:id="@+id/header_account_balance_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/header_account_balance"
+            app:layout_constraintStart_toStartOf="@id/header_account_balance"
+            android:layout_marginTop="2dp"
+            style="@style/accountBalanceTitle"
+            android:alpha=".75"
+            android:text="@string/account_balance_title"/>
+        <ImageView
+            android:id="@+id/header_card_image"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:src="@drawable/card_icon"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
     <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
         <LinearLayout
@@ -17,11 +54,17 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="14dp"
             android:layout_marginHorizontal="18dp">
+            <ProgressBar
+                android:id="@+id/loading"
+                android:layout_width="match_parent"
+                android:layout_height="30dp"
+                app:layout_constraintTop_toTopOf="parent"
+                android:visibility="gone"/>
             <TextView
                 android:id="@+id/account_balance"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/loading"
                 app:layout_constraintStart_toStartOf="parent"
                 style="@style/accountBalance"/>
             <TextView


### PR DESCRIPTION
Added custom pull to refresh ability - tracks scrolls up near the top of the screen and loops a 1 second loading view, then hides it and drops back down to 1px to enable a new pull if needed.

Added header view - will appear if the search bar is not visible on screen, and disappear once scrolling back down to search bar